### PR TITLE
Removing some research functions that broke compiling for windows

### DIFF
--- a/research_functions.go
+++ b/research_functions.go
@@ -71,33 +71,43 @@ func (e *Engine) VMCanReadFile(call otto.FunctionCall) otto.Value {
 }
 
 func (e *Engine) VMCanWriteFile(call otto.FunctionCall) otto.Value {
-	filePath := call.Argument(0)
-	filePathString, err := filePath.Export()
-	if err != nil {
-		e.LogErrorf("Function Error: function=%s error=ARY_ARG_NOT_String arg=%s", CalledBy(), spew.Sdump(err))
-		return otto.FalseValue()
-	}
-	result := LocalFileWritable(filePathString.(string))
-	if result == true {
-		return otto.TrueValue()
-	} else {
-		return otto.FalseValue()
-	}
+	e.LogErrorf("Function Not Implemented: %s", CalledBy())
+	return otto.FalseValue()
+	//Following code breaks building for windows :(
+	/*
+		filePath := call.Argument(0)
+		filePathString, err := filePath.Export()
+		if err != nil {
+			e.LogErrorf("Function Error: function=%s error=ARY_ARG_NOT_String arg=%s", CalledBy(), spew.Sdump(err))
+			return otto.FalseValue()
+		}
+		result := LocalFileWritable(filePathString.(string))
+		if result == true {
+			return otto.TrueValue()
+		} else {
+			return otto.FalseValue()
+		}
+	*/
 }
 
 func (e *Engine) VMCanExecFile(call otto.FunctionCall) otto.Value {
-	filePath := call.Argument(0)
-	filePathString, err := filePath.Export()
-	if err != nil {
-		e.LogErrorf("Function Error: function=%s error=ARY_ARG_NOT_String arg=%s", CalledBy(), spew.Sdump(err))
-		return otto.FalseValue()
-	}
-	result := LocalFileExecutable(filePathString.(string))
-	if result {
-		return otto.TrueValue()
-	} else {
-		return otto.FalseValue()
-	}
+	e.LogErrorf("Function Not Implemented: %s", CalledBy())
+	return otto.FalseValue()
+	//Following code breaks building for windows :(
+	/*
+		filePath := call.Argument(0)
+		filePathString, err := filePath.Export()
+		if err != nil {
+			e.LogErrorf("Function Error: function=%s error=ARY_ARG_NOT_String arg=%s", CalledBy(), spew.Sdump(err))
+			return otto.FalseValue()
+		}
+		result := LocalFileExecutable(filePathString.(string))
+		if result {
+			return otto.TrueValue()
+		} else {
+			return otto.FalseValue()
+		}
+	*/
 }
 
 func (e *Engine) VMFileExists(call otto.FunctionCall) otto.Value {

--- a/util.go
+++ b/util.go
@@ -14,13 +14,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 	"unicode"
 
 	"github.com/matishsiao/goInfo"
 	"github.com/mitchellh/go-ps"
-	"golang.org/x/sys/unix"
 )
 
 func CalledBy() string {
@@ -44,6 +42,8 @@ func LocalFileExists(path string) bool {
 	return false
 }
 
+//These two functions break compiling on windows
+/*
 func LocalFileWritable(path string) bool {
 	return unix.Access(path, unix.W_OK) == nil
 }
@@ -51,6 +51,7 @@ func LocalFileWritable(path string) bool {
 func LocalFileExecutable(path string) bool {
 	return unix.Access(path, unix.X_OK) == nil
 }
+*/
 
 func LocalDirCreate(path string) error {
 	err := os.MkdirAll(path, 0700)
@@ -393,11 +394,14 @@ func UDPWrite(writeData []byte, ip, port string) error {
 	return nil
 }
 
+//Function breaks compiling on windows
+/*
 func ProcExists1(pidBoi int) bool {
 	killErr := syscall.Kill(pidBoi, syscall.Signal(0))
 	procExistsBoi := (killErr == nil || killErr == syscall.EPERM)
 	return procExistsBoi
 }
+*/
 
 func ProcExists2(pidBoi int) bool {
 	process, err := ps.FindProcess(pidBoi)


### PR DESCRIPTION
Removing some research functions that included unix only libraries breaking compatibility with Windows. These research functions were not currently in use, so little impact removing them.